### PR TITLE
Rt issue 9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     forge
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.2.0
 Suggests: 
     testthat (>= 2.1.0),
     covr

--- a/R/ctgan.R
+++ b/R/ctgan.R
@@ -6,23 +6,26 @@
 #' @param embedding_dim Dimension of embedding layer.
 #' @param gen_dim Dimensions of generator layers.
 #' @param dis_dim Dimensions of discriminator layers.
-#' @param l2_scale ADAM weight decay.
+#' @param gen_decay Generator weight decay for ADAM Optimizer.
+#' @param dis_decay Discriminator weight decay for ADAM Optimizer.
 #' @param batch_size Batch size.
 #' @export
 ctgan <- function(embedding_dim = 128, gen_dim = c(256, 256),
-                  dis_dim = c(256, 256), l2_scale = 1e-6, batch_size = 500) {
+                  dis_dim = c(256, 256), gen_decay = 1e-6, dis_decay = gen_decay, batch_size = 500) {
   embedding_dim <- cast_integer(embedding_dim)
   gen_dim <- cast_integer(gen_dim)
   dis_dim <- cast_integer(dis_dim)
-  l2_scale <- cast_scalar_double(l2_scale)
+  gen_decay <- cast_scalar_double(gen_decay)
+  dis_decay <- cast_scalar_double(dis_decay)
   batch_size <- cast_scalar_integer(batch_size)
 
   ctgan <- reticulate::import("ctgan")
   model <- ctgan$CTGANSynthesizer(
     embedding_dim = embedding_dim,
-    gen_dim = gen_dim,
-    dis_dim = dis_dim,
-    l2scale = l2_scale,
+    generator_dim = gen_dim,
+    discriminator_dim  = dis_dim,
+    generator_decay = gen_decay,
+    discriminator_decay = dis_decay,
     batch_size = batch_size
   )
 

--- a/R/ctgan.R
+++ b/R/ctgan.R
@@ -9,15 +9,21 @@
 #' @param gen_decay Generator weight decay for ADAM Optimizer.
 #' @param dis_decay Discriminator weight decay for ADAM Optimizer.
 #' @param batch_size Batch size.
+#' @param log_frequency Whether to use log frequency of categorical levels in
+#' conditional sampling. Defaults to TRUE.
+#'
 #' @export
 ctgan <- function(embedding_dim = 128, gen_dim = c(256, 256),
-                  dis_dim = c(256, 256), gen_decay = 1e-6, dis_decay = gen_decay, batch_size = 500) {
+                  dis_dim = c(256, 256), gen_decay = 1e-6,
+                  dis_decay = gen_decay, batch_size = 500,
+                  log_frequency = TRUE) {
   embedding_dim <- cast_integer(embedding_dim)
   gen_dim <- cast_integer(gen_dim)
   dis_dim <- cast_integer(dis_dim)
   gen_decay <- cast_scalar_double(gen_decay)
   dis_decay <- cast_scalar_double(dis_decay)
   batch_size <- cast_scalar_integer(batch_size)
+  log_frequency <- cast_scalar_logical(log_frequency)
 
   ctgan <- reticulate::import("ctgan")
   model <- ctgan$CTGANSynthesizer(
@@ -26,7 +32,8 @@ ctgan <- function(embedding_dim = 128, gen_dim = c(256, 256),
     discriminator_dim  = dis_dim,
     generator_decay = gen_decay,
     discriminator_decay = dis_decay,
-    batch_size = batch_size
+    batch_size = batch_size,
+    log_frequency = log_frequency
   )
 
   CTGANModel$new(model)
@@ -39,7 +46,7 @@ CTGANModel <- R6::R6Class(
       private$model_obj <- model_obj
       private$metadata <- metadata
     },
-    fit = function(train_data, epochs, log_frequency) {
+    fit = function(train_data, epochs) {
       c(train_data, metadata) %<-% transform_data(train_data)
 
       categorical_col_indices <- which(metadata$col_info$type == "nominal") - 1
@@ -54,8 +61,7 @@ CTGANModel <- R6::R6Class(
       private$model_obj$fit(
         train_data = as.matrix(train_data),
         discrete_columns = categorical_columns,
-        epochs = epochs,
-        log_frequency = log_frequency
+        epochs = epochs
       )
     },
     sample = function(n) {
@@ -96,18 +102,15 @@ CTGANModel <- R6::R6Class(
 #' @param object A `CTGANModel` object.
 #' @param train_data Training data, should be a data frame.
 #' @param epochs Number of epochs to train.
-#' @param log_frequency Whether to use log frequency of categorical levels in
-#'   conditional sampling. Defaults to `TRUE`.
 #' @param ... Additional arguments, currently unused.
 #'
 #' @export
 fit.CTGANModel <-
   function(object, train_data,
-           epochs = 100, log_frequency = TRUE,...) {
+           epochs = 100,...) {
     epochs <- cast_scalar_integer(epochs)
-    log_frequency <- cast_scalar_logical(log_frequency)
 
-    object$fit(train_data, epochs, log_frequency)
+    object$fit(train_data, epochs)
 
     invisible(NULL)
   }

--- a/man/ctgan.Rd
+++ b/man/ctgan.Rd
@@ -8,7 +8,8 @@ ctgan(
   embedding_dim = 128,
   gen_dim = c(256, 256),
   dis_dim = c(256, 256),
-  l2_scale = 1e-06,
+  gen_decay = 1e-06,
+  dis_decay = gen_decay,
   batch_size = 500
 )
 }
@@ -19,7 +20,9 @@ ctgan(
 
 \item{dis_dim}{Dimensions of discriminator layers.}
 
-\item{l2_scale}{ADAM weight decay.}
+\item{gen_decay}{Generator weight decay for ADAM Optimizer.}
+
+\item{dis_decay}{Discriminator weight decay for ADAM Optimizer.}
 
 \item{batch_size}{Batch size.}
 }


### PR DESCRIPTION
initial work on addressing #9 

Problem was arguments for underlying python modules have changed names and location (e.g. gen_dims is now generator_dims and log_frequency is in the CTGANSynthesizer constructor instead of the fit method.

I'm still getting some convergence warnings when I try to run the example in the README but I created this PR because I thought @kevinykuo  might be able to sort that quicker than me.